### PR TITLE
added missing error message to fatal output

### DIFF
--- a/go-cron.go
+++ b/go-cron.go
@@ -61,7 +61,7 @@ func execute(command string, args []string) {
 		log.Fatal(err)
 	}
 	if err := cmd.Start(); err != nil {
-		log.Fatalf("cmd.Start: %v")
+		log.Fatalf("cmd.Start: %v", err)
 	}
 
 	run.Pid = cmd.Process.Pid


### PR DESCRIPTION
very simple change - one of the error messages was missing the actual error for its %v placeholder